### PR TITLE
Added SEA so gun.user() would work

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You can either pass in a `gun` instance fully initialized, or allow VueGun to in
 
 ```javascript
 import VueGun from 'vue-gun';
+import SEA from 'gun/sea'; // Required for SEA functions and user authentication 
 Vue.use(VueGun, {
     gun: gun // must be passed in at `gun` key
 });

--- a/vue-gun.js
+++ b/vue-gun.js
@@ -4,7 +4,6 @@ module.exports = {
             Vue.prototype.$gun = options.gun;
         } else {
             var Gun = require('gun');
-            var SEA = require('gun/sea');
             Vue.prototype.$gun = Gun(options);
         }
     }

--- a/vue-gun.js
+++ b/vue-gun.js
@@ -4,6 +4,7 @@ module.exports = {
             Vue.prototype.$gun = options.gun;
         } else {
             var Gun = require('gun');
+            var SEA = require('gun/sea');
             Vue.prototype.$gun = Gun(options);
         }
     }


### PR DESCRIPTION
I was getting this error when trying to create a new users with `this.$gun.user()`. Making this change seems to fix the issue. It looks `gun.user()` is dependent on SEA and it just wasn't being imported.
![screenshot_2018-07-14_23-34-12](https://user-images.githubusercontent.com/1785592/42730261-87482d50-87be-11e8-8a0d-3f592f2c7348.png)

Obviously the workaround for this is to just use your own instance of gun with the SEA import, but it wasn't obvious to me. I figured vue-gun's default configuration would just come with SEA, and the gunjs docs don't list any options that can be passed to Gun() to enabled SEA without an import of SEA.

If you prefer the workaround to importing SEA by default, then I suggest it be added to the README so users following the gunjs tutorials will  know that they have to import SEA in order to use `gun.user()`

```javascript
// Workaround
import Gun from 'gun';
import SEA from 'gun/sea';

var gun = Gun();
Vue.use(VueGun, {gun: gun});
```